### PR TITLE
add warning for ruby with ghidra 10.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.1] - 2021-09-27
+### Fixed
+ - Add warning and patch `support/launch.properties` file for Ghidra 10.0.3
+   problems with class lookups.
+
+
 ## [1.0.0] - 2021-08-29
 ### Added
  - Add headless support to example scripts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    problems with class lookups.
 
 
+### Changed
+ - Upgrade to JRuby 9.3.0.0 (Ruby 2.6.8)
+
+
 ## [1.0.0] - 2021-08-29
 ### Added
  - Add headless support to example scripts.
@@ -24,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Clojure script capability (uses Clojure 1.10.3).
 
 
-###Changed
+### Changed
  - Upgrade to JRuby 9.2.19.0 (Ruby 2.5.8).
 
 

--- a/data/launch.properties
+++ b/data/launch.properties
@@ -1,0 +1,109 @@
+# Force Ghidra's Java home instead of trying to figure it out automatically.
+# If the provided path does not point to a supported Java home that Ghidra
+# supports, this property is ignored.
+# NOTE: Ghidra requires a JDK to launch.
+JAVA_HOME_OVERRIDE=
+
+# Required Ghidra class loader
+VMARGS=-Djava.system.class.loader=ghidra.GhidraClassLoader
+
+# Set default encoding to UTF8
+VMARGS=-Dfile.encoding=UTF8
+
+# Set locale (only en_US is supported)
+VMARGS=-Duser.country=US
+VMARGS=-Duser.language=en
+VMARGS=-Duser.variant=
+
+# The following options affect rendering on different platforms.  It may be necessary to play
+# with these settings to get Ghidra to display and perform optimally on HiDPI monitors or in VM's.
+VMARGS=-Dsun.java2d.opengl=false
+VMARGS_LINUX=-Dsun.java2d.pmoffscreen=false
+VMARGS_LINUX=-Dsun.java2d.xrender=true
+VMARGS_LINUX=-Dsun.java2d.uiScale=1
+VMARGS_LINUX=-Dawt.useSystemAAFontSettings=on
+VMARGS_WINDOWS=-Dsun.java2d.d3d=false
+
+# The Ghidra application establishes the default SSLContext for all
+# secure client connections based upon Java's default TLS protocol enablement.
+# Setting this property will restrict the enabled TLS protocol versions for
+# all secure network connections.  Specifying multiple protocols must be
+# comma-separated (e.g., TLSv1.2,TLSv1.3).  See https://java.com/en/configure_crypto.html
+# for details on configuring Java's cryptographic algorithms.
+VMARGS=-Djdk.tls.client.protocols=TLSv1.2,TLSv1.3
+
+# Force PKI server authentication of all HTTPS and Ghidra Server connections by
+# specifying path to installed CA certificates file.
+# VMARGS=-Dghidra.cacerts=
+
+# The following property will limit the number of processor cores that Ghidra
+# will use for thread pools. If not specified, it will use the default number
+# of processors returned from Runtime.getRuntime().getAvailableProcessors().
+# Otherwise, it will use the min of the value returned from Runtime and the
+# value specified by the following property.
+VMARGS=-Dcpu.core.limit=
+
+# The following property is a way to exactly specify the number of processor
+# cores that Ghidra will use for thread pools.  Note: this will supersede the
+# above 'cpu.core.limit' value if it is set.
+VMARGS=-Dcpu.core.override=
+
+# Default font size for many java swing elements.
+VMARGS=-Dfont.size.override=
+
+# Set Jython console encoding (prevents a console error)
+VMARGS=-Dpython.console.encoding=UTF-8
+
+# Eclipse on macOS can have file locking issues if the user home directory is networked.  Therefore,
+# we will disable file locking by default for macOS. Comment the following line out if Eclipse file
+# locking is needed and known to work.
+VMARGS_MACOS=-Declipse.filelock.disable=true
+
+# Where the menu bar is displayed on macOS
+VMARGS_MACOS=-Dapple.laf.useScreenMenuBar=false
+
+# Prevent log4j from using the Jansi DLL on Windows.
+VMARGS_WINDOWS=-Dlog4j.skipJansi=true
+
+# Custom class loader usage forces class data sharing to be disabled which produces a warning.
+# Ghidra does not use class data sharing, so explicitly turn it off to avoid the warning.
+VMARGS=-Xshare:off
+
+# Permit "illegal reflective accesses" to enable JDK compatibility with Ghidra and 3rd party jars.
+VMARGS=--add-opens java.base/java.lang=ALL-UNNAMED
+VMARGS=--add-opens java.base/java.util=ALL-UNNAMED
+VMARGS=--add-opens java.base/java.net=ALL-UNNAMED
+VMARGS=--add-opens java.base/sun.net.www.protocol.file=ALL-UNNAMED
+VMARGS=--add-opens java.base/sun.net.www.protocol.ftp=ALL-UNNAMED
+VMARGS=--add-opens java.base/sun.net.www.protocol.http=ALL-UNNAMED
+VMARGS=--add-opens java.base/sun.net.www.protocol.https=ALL-UNNAMED
+VMARGS=--add-opens java.base/sun.net.www.protocol.jar=ALL-UNNAMED
+VMARGS=--add-opens java.desktop/sun.awt.image=ALL-UNNAMED
+VMARGS_LINUX=--add-opens java.desktop/sun.awt.X11=ALL-UNNAMED
+
+# Persistent cache directory used by the application.  This directory will be used to store
+# persistent application caches for all users.  The default location for Mac/Linux is the same as
+# specified by java.io.tmpdir property. The default location for Windows corresponds to the
+# application local settings directory for the user (e.g., %LOCALAPPDATA%). If you wish to use a
+# directory with more storage or avoid system cleanups, it may be desirable to override the default
+# location.
+#VMARGS=-Dapplication.cachedir=
+
+# Temporary directory used by the application.  This directory will be used for all temporary files
+# and may also be used for the persistent user cache directory <java.io.tmpdir>/<username>-Ghidra.
+# The specified directory must exist and have appropriate read/write/execute permissions
+#VMARGS=-Djava.io.tmpdir=
+
+# Disable alternating row colors in tables
+#VMARGS=-Ddisable.alternating.row.colors=true
+
+# The ContinuesInterceptor allows the import process to proceed if parsing corrupted headers
+# generates uncaught exceptions.  Its usage has been deprecated and will be removed in a future
+# release of Ghidra.  It is disabled by default.
+#VMARGS=-DContinuesInterceptor.enabled=true
+
+# Limit on XML parsing. See https://docs.oracle.com/javase/tutorial/jaxp/limits/limits.html
+#VMARGS=-Djdk.xml.totalEntitySizeLimit=50000000
+
+# Enables Pdb debug logging during import and analysis to .ghidra/.ghidra_ver/pdb.analyzer.log
+#VMARGS=-Dpdb.logging=true

--- a/src/main/java/rubydragon/ruby/RubyDragonPlugin.java
+++ b/src/main/java/rubydragon/ruby/RubyDragonPlugin.java
@@ -18,6 +18,7 @@
 
 package rubydragon.ruby;
 
+import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -30,6 +31,7 @@ import ghidra.app.plugin.core.console.CodeCompletion;
 import ghidra.app.plugin.core.interpreter.InterpreterConnection;
 import ghidra.app.plugin.core.interpreter.InterpreterConsole;
 import ghidra.app.plugin.core.interpreter.InterpreterPanelService;
+import ghidra.framework.Application;
 import ghidra.framework.plugintool.PluginInfo;
 import ghidra.framework.plugintool.PluginTool;
 import ghidra.framework.plugintool.util.PluginStatus;
@@ -115,6 +117,18 @@ public class RubyDragonPlugin extends ProgramPlugin implements InterpreterConnec
 		console = getTool().getService(InterpreterPanelService.class).createInterpreterPanel(this, false);
 		interpreter = new RubyGhidraInterpreter(console);
 		console.addFirstActivationCallback(() -> {
+			String ghidraVersion = Application.getApplicationVersion();
+			if (ghidraVersion.equals("10.0.3")) {
+				PrintWriter errWriter = new PrintWriter(console.getStdErr());
+				errWriter.print("RubyDragon may have problems running in Ghidra "
+						+ "10.0.3. If you receive errors regarding class lookup "
+						+ "failures, you may need to replace the launch.properties "
+						+ "file in the support directory of the Ghidra install "
+						+ "with the one in this plugin (in the "
+						+ "Extensions/RubyDragon/data directory in your Ghidra install).\n");
+				errWriter.flush();
+			}
+
 			interpreter.startInteractiveSession();
 		});
 	}


### PR DESCRIPTION
This change updates the version of JRuby, and adds a warning message and patch file to the plugin to address potential errors when used with Ghidra 10.0.3. These changes address an issue regarding class lookups from plugins in newer JDK versions arising from illegal reflective accesses from the Apache Felix framework.

This addresses #9, which can be referenced for more details.