### PR TITLE
add warning for ruby in ghidra 10.0.4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,18 +12,18 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        ghidra: ["9.2.4", "10.0.3"]
+        ghidra: ["9.2.4", "10.0.4"]
         include:
           - ghidra: "9.2.4"
             ghidra-url: "https://github.com/NationalSecurityAgency/ghidra/releases/download/Ghidra_9.2.4_build/ghidra_9.2.4_PUBLIC_20210427.zip"
             ghidra-sha256: "c1f18cdb12e2e1c0313e7becf7f0387226937ac67ad6c6e5056fa889229f969a"
             ghidra-filename: "ghidra_9.2.4_PUBLIC_20210427.zip"
             ghidra-folder: "ghidra_9.2.4_PUBLIC"
-          - ghidra: "10.0.3"
-            ghidra-url: "https://github.com/NationalSecurityAgency/ghidra/releases/download/Ghidra_10.0.3_build/ghidra_10.0.3_PUBLIC_20210908.zip"
-            ghidra-sha256: "1e1d363c18622b9477bddf0cc172ec55e56cac1416b332a5c53906a78eb87989"
-            ghidra-filename: "ghidra_10.0.3_PUBLIC_20210908.zip"
-            ghidra-folder: "ghidra_10.0.3_PUBLIC"
+          - ghidra: "10.0.4"
+            ghidra-url: "https://github.com/NationalSecurityAgency/ghidra/releases/download/Ghidra_10.0.4_build/ghidra_10.0.4_PUBLIC_20210928.zip"
+            ghidra-sha256: "1ce9bdf2d7f6bdfe5dccd06da828af31bc74acfd800f71ade021d5211e820d5e"
+            ghidra-filename: "ghidra_10.0.4_PUBLIC_202109028.zip"
+            ghidra-folder: "ghidra_10.0.4_PUBLIC"
 
     env:
       GHIDRA_INSTALL_DIR: /home/runner/ghidra/${{ matrix.ghidra-folder }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
           - ghidra: "10.0.4"
             ghidra-url: "https://github.com/NationalSecurityAgency/ghidra/releases/download/Ghidra_10.0.4_build/ghidra_10.0.4_PUBLIC_20210928.zip"
             ghidra-sha256: "1ce9bdf2d7f6bdfe5dccd06da828af31bc74acfd800f71ade021d5211e820d5e"
-            ghidra-filename: "ghidra_10.0.4_PUBLIC_202109028.zip"
+            ghidra-filename: "ghidra_10.0.4_PUBLIC_20210928.zip"
             ghidra-folder: "ghidra_10.0.4_PUBLIC"
 
     env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.2] - 2021-10-03
+### Fixed
+ - Expand class lookup warning to also appear for Ghidra 10.0.4.
+
+
 ## [1.0.1] - 2021-09-27
 ### Fixed
  - Add warning and patch `support/launch.properties` file for Ghidra 10.0.3

--- a/src/main/java/rubydragon/ruby/RubyDragonPlugin.java
+++ b/src/main/java/rubydragon/ruby/RubyDragonPlugin.java
@@ -20,6 +20,7 @@ package rubydragon.ruby;
 
 import java.io.PrintWriter;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import javax.swing.ImageIcon;
@@ -117,11 +118,12 @@ public class RubyDragonPlugin extends ProgramPlugin implements InterpreterConnec
 		console = getTool().getService(InterpreterPanelService.class).createInterpreterPanel(this, false);
 		interpreter = new RubyGhidraInterpreter(console);
 		console.addFirstActivationCallback(() -> {
+			List<String> brokenVersions = Arrays.asList("10.0.3", "10.0.4");
 			String ghidraVersion = Application.getApplicationVersion();
-			if (ghidraVersion.equals("10.0.3")) {
+			if (brokenVersions.contains(ghidraVersion)) {
 				PrintWriter errWriter = new PrintWriter(console.getStdErr());
-				errWriter.print("RubyDragon may have problems running in Ghidra "
-						+ "10.0.3. If you receive errors regarding class lookup "
+				errWriter.print("RubyDragon may have problems running in this "
+						+ "version of Ghidra. If you receive errors regarding class lookup "
 						+ "failures, you may need to replace the launch.properties "
 						+ "file in the support directory of the Ghidra install "
 						+ "with the one in this plugin (in the "

--- a/src/test/resources/expected/10.0.4-GhidraBasicsScriptClj.txt
+++ b/src/test/resources/expected/10.0.4-GhidraBasicsScriptClj.txt
@@ -1,0 +1,91 @@
+Program Info:
+HelloGhidra.exe x86:LE:32:default (windows)
+
+Memory Layout:
+Imagebase: 0x400000
+Headers [start: 0x00400000, end:0x004003ff]
+.text [start: 0x00401000, end:0x00401fff]
+.rdata [start: 0x00402000, end:0x00402fff]
+.data [start: 0x00403000, end:0x004031ff]
+.data [start: 0x00403200, end:0x00403387]
+.rsrc [start: 0x00404000, end:0x004041ff]
+.reloc [start: 0x00405000, end:0x004051ff]
+
+Function List:
+FUN_00401000
+FUN_00401010
+Catch_All@004011b0
+FUN_004012ea
+entry
+FUN_00401549
+FUN_00401571
+find_pe_section
+___scrt_acquire_startup_lock
+___scrt_initialize_crt
+___scrt_initialize_onexit_tables
+___scrt_is_nonwritable_in_current_image
+___scrt_release_startup_lock
+___scrt_uninitialize_crt
+__onexit
+_atexit
+___get_entropy
+___security_init_cookie
+FUN_00401954
+FUN_00401957
+FUN_0040195b
+FUN_00401961
+FUN_0040196d
+FUN_00401970
+_guard_check_icall
+FUN_00401994
+FUN_0040199a
+FUN_004019a0
+FUN_004019bd
+FUN_004019c9
+FUN_004019cf
+FUN_004019d5
+thunk_FUN_00401954
+FUN_00401af5
+FUN_00401b44
+FUN_00401b9a
+FUN_00401ba2
+__SEH_prolog4
+__except_handler4
+FUN_00401c74
+___scrt_is_ucrt_dll_in_use
+Unwind@00401e57
+__current_exception
+__current_exception_context
+memset
+_except_handler4_common
+_seh_filter_exe
+_set_app_type
+__setusermatherr
+_configure_narrow_argv
+_initialize_narrow_environment
+_get_initial_narrow_environment
+_initterm
+_initterm_e
+exit
+_exit
+_set_fmode
+__p___argc
+__p___argv
+_cexit
+_c_exit
+_register_thread_local_exe_atexit_callback
+_configthreadlocale
+__p__commode
+_initialize_onexit_table
+_register_onexit_function
+_crt_atexit
+_controlfp_s
+terminate
+__filter_x86_sse2_floating_point_exception_default
+Unwind@00401f80
+Unwind@00401f88
+
+Current Location: 0x4194304
+
+You entered 'HeadlessTest'
+

--- a/src/test/resources/expected/10.0.4-GhidraBasicsScriptRb.txt
+++ b/src/test/resources/expected/10.0.4-GhidraBasicsScriptRb.txt
@@ -1,0 +1,89 @@
+Program Info:
+HelloGhidra.exe x86:LE:32:default (windows)
+
+Memory Layout:
+Imagebase: 0x400000
+Headers [start: 0x00400000, end: 0x004003ff]
+.text [start: 0x00401000, end: 0x00401fff]
+.rdata [start: 0x00402000, end: 0x00402fff]
+.data [start: 0x00403000, end: 0x004031ff]
+.data [start: 0x00403200, end: 0x00403387]
+.rsrc [start: 0x00404000, end: 0x004041ff]
+.reloc [start: 0x00405000, end: 0x004051ff]
+
+Function List:
+FUN_00401000
+FUN_00401010
+Catch_All@004011b0
+FUN_004012ea
+entry
+FUN_00401549
+FUN_00401571
+find_pe_section
+___scrt_acquire_startup_lock
+___scrt_initialize_crt
+___scrt_initialize_onexit_tables
+___scrt_is_nonwritable_in_current_image
+___scrt_release_startup_lock
+___scrt_uninitialize_crt
+__onexit
+_atexit
+___get_entropy
+___security_init_cookie
+FUN_00401954
+FUN_00401957
+FUN_0040195b
+FUN_00401961
+FUN_0040196d
+FUN_00401970
+_guard_check_icall
+FUN_00401994
+FUN_0040199a
+FUN_004019a0
+FUN_004019bd
+FUN_004019c9
+FUN_004019cf
+FUN_004019d5
+thunk_FUN_00401954
+FUN_00401af5
+FUN_00401b44
+FUN_00401b9a
+FUN_00401ba2
+__SEH_prolog4
+__except_handler4
+FUN_00401c74
+___scrt_is_ucrt_dll_in_use
+Unwind@00401e57
+__current_exception
+__current_exception_context
+memset
+_except_handler4_common
+_seh_filter_exe
+_set_app_type
+__setusermatherr
+_configure_narrow_argv
+_initialize_narrow_environment
+_get_initial_narrow_environment
+_initterm
+_initterm_e
+exit
+_exit
+_set_fmode
+__p___argc
+__p___argv
+_cexit
+_c_exit
+_register_thread_local_exe_atexit_callback
+_configthreadlocale
+__p__commode
+_initialize_onexit_table
+_register_onexit_function
+_crt_atexit
+_controlfp_s
+terminate
+__filter_x86_sse2_floating_point_exception_default
+Unwind@00401f80
+Unwind@00401f88
+
+Current location: 0x400000
+You entered 'HeadlessTest'


### PR DESCRIPTION
The class loading errors also occur in ghidra 10.0.4, so the warning has been expanded to show in this version as well.