### PR TITLE
refactor and improve jshell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [1.3.0] - 2022-07-18
+## [1.3.0] - 2022-07-29
 ### Added
  - JShell interactive interpreter
+ - currentAPI interpreter variables with `FlatProgramAPI` instance
 
 
 ## [1.2.0] - 2022-06-11

--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ $current_program
 $current_selection
 ```
 
+Another variable named `$current_api` is also provided, which is an instance of
+`FlatProgramAPI` created with `currentProgram`. This has many (but not all) of
+the convenience functions that would be available within a `GhidraScript`
+instance.
+
 You can also write scripts in Ruby, much the same way as you would with Java or
 Python. Ruby will be available as a new script type, and you can see several
 example scripts in the `Examples.Ruby` directory of the Script Manager that
@@ -83,6 +88,9 @@ currentProgram
 currentSelection
 ```
 
+`currentAPI` is also provided similar to the Ruby interpreter, again holding an
+instance of `FlatProgramAPI` created with `currentProgram`.
+
 Kotlin scripts use a `kts` extension as they are interpreted as scripts rather
 than being compiled to java first.
 
@@ -100,10 +108,8 @@ currentProgram
 currentSelection
 ```
 
-Another variable named `currentAPI` is also provided, which is an instance of
-`FlatProgramAPI` created with `currentProgram`. This has many (but not all) of
-the convenience functions that would be available within a `GhidraScript`
-instance.
+`currentAPI` is also provided as with the Kotlin interpreter, again holding an
+instance of `FlatProgramAPI` created with `currentProgram`.
 
 This interpreter is especially handy when writing Java scripts, as it allows you
 to iteratively test snippets of code from the script without needing to do any
@@ -124,6 +130,9 @@ ghidra/current-location
 ghidra/current-program
 ghidra/current-selection
 ```
+
+`ghidra/current-api` is provided as the instance of `FlatProgramAPI` created
+with `currentProgram`, as with the other interpreters.
 
 And, as with Ruby, a `ghidra/script` binding is available within scripts that
 provides access to the underlying `ClojureScript` instance. Unlike Ruby however,

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 [![build](https://github.com/goatshriek/ruby-dragon/actions/workflows/build.yml/badge.svg)](https://github.com/goatshriek/ruby-dragon/actions/workflows/build.yml)
 [![Apache 2.0 License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
-Ruby, Kotlin, JShell, and Clojure support for Ghidra, both interactive and
-scripting.
+[Ruby](#ruby-usage), [Kotlin](#kotlin-usage), [JShell](#jshell-usage), and
+[Clojure](#clojure-usage) support for Ghidra, both interactive and scripting.
 
 
 ## Installation
@@ -99,6 +99,11 @@ currentLocation
 currentProgram
 currentSelection
 ```
+
+Another variable named `currentAPI` is also provided, which is an instance of
+`FlatProgramAPI` created with `currentProgram`. This has many (but not all) of
+the convenience functions that would be available within a `GhidraScript`
+instance.
 
 This interpreter is especially handy when writing Java scripts, as it allows you
 to iteratively test snippets of code from the script without needing to do any

--- a/extension.properties
+++ b/extension.properties
@@ -1,5 +1,5 @@
 name=RubyDragon
-description=Ruby, Kotlin, and Clojure interpreters.
+description=Ruby, Kotlin, JShell, and Clojure interpreters.
 author=goatshriek
 createdOn=
 version=@extversion@

--- a/src/main/help/help/topics/rubydragon/clojure.html
+++ b/src/main/help/help/topics/rubydragon/clojure.html
@@ -44,6 +44,13 @@
     </PRE>
 
     <P>
+    In the interactive interpreter, there is also another variable named
+    ghidra/current-api, which has an instance of FlatProgramAPI for the current
+    program. This can be used to access the convenience functions provided by
+    the flat API.
+    </P>
+
+    <P>
     If you're writing a script, you'll also be able to access the ClojureScript
     instance (a subclass of GhidraScript) using the ghidra/script
     binding. This will provide access to all public fields and methods for the

--- a/src/main/help/help/topics/rubydragon/jshell.html
+++ b/src/main/help/help/topics/rubydragon/jshell.html
@@ -42,6 +42,12 @@
     currentProgram
     currentSelection
     </PRE>
+
+    <P>
+    There is also an extra variable named currentAPI which provides an instance
+    of FlatProgramAPI created using currentProgram. This provides many (though
+    not all) convenience functions available in a GhidraScript instance.
+    </P>
     </BLOCKQUOTE>
 
     <H2>Copy/Paste</H2>

--- a/src/main/help/help/topics/rubydragon/kotlin.html
+++ b/src/main/help/help/topics/rubydragon/kotlin.html
@@ -42,6 +42,13 @@
     </PRE>
 
     <P>
+    In the interactive interpreter, there is also another variable named
+    currentAPI, which has an instance of FlatProgramAPI for the current
+    program. This can be used to access the convenience functions provided by
+    the flat API.
+    </P>
+
+    <P>
     If you're writing a script, you'll also be able to access the KotlinScript
     instance (a subclass of GhidraScript) using the script variable binding.
     This will provide access to all public fields and methods for the

--- a/src/main/help/help/topics/rubydragon/ruby.html
+++ b/src/main/help/help/topics/rubydragon/ruby.html
@@ -47,13 +47,19 @@
     </PRE>
 
     <P>
+    In the interactive interpreter, there is also another global variable named
+    $current_api, which has an instance of FlatProgramAPI for the current
+    program. This can be used to access the convenience functions provided by
+    the flat API.
+    </P>
+
+    <P>
     If you're writing a script, you'll also be able to access the RubyScript
     instance (a subclass of GhidraScript) using the $script binding. This
-    will provide access to all fields and methods for the
-    instance. For example, to access the TaskMonitor for the script, simply
-    use $script.monitor. There are examples of this
-    in the GhidraBasicsScriptRuby script included in the Examples category with
-    this plugin.
+    will provide access to all fields and methods for the instance.
+    For example, to access the TaskMonitor for the script, simply use
+    $script.monitor. There are examples of this in the GhidraBasicsScriptRuby
+    script included in the Examples category with this plugin.
     </P>
     </BLOCKQUOTE>
 

--- a/src/main/java/rubydragon/GhidraInterpreter.java
+++ b/src/main/java/rubydragon/GhidraInterpreter.java
@@ -18,16 +18,12 @@
 
 package rubydragon;
 
-import java.io.FileNotFoundException;
-import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintWriter;
 import java.util.List;
 
 import ghidra.app.plugin.core.console.CodeCompletion;
 import ghidra.app.plugin.core.interpreter.InterpreterConsole;
-import ghidra.app.script.GhidraScript;
-import ghidra.app.script.GhidraState;
 import ghidra.program.model.address.Address;
 import ghidra.program.model.listing.Program;
 import ghidra.program.util.ProgramLocation;
@@ -35,12 +31,14 @@ import ghidra.program.util.ProgramSelection;
 import ghidra.util.Disposable;
 
 /**
- * An interpreter that users can use interactively as well as to run custom
- * scripts.
+ * An interpreter that users can use interactively.
  *
  * This class provides a common base that all interpreters should implement in
  * order to fit in to the overall system. It provides a common wrapper around
  * the language-specific internals of a given language environment.
+ *
+ * Interpreters that also support scripts should inherit from
+ * ScriptableGhidraInterpreter instead.
  */
 public abstract class GhidraInterpreter implements Disposable {
 
@@ -50,22 +48,6 @@ public abstract class GhidraInterpreter implements Disposable {
 	public abstract void dispose();
 
 	/**
-	 * Loads a provided GhidraState into the interpreter.
-	 *
-	 * @param state The state to load.
-	 */
-	public void loadState(GhidraState state) {
-		updateHighlight(state.getCurrentHighlight());
-		updateLocation(state.getCurrentLocation());
-		updateSelection(state.getCurrentSelection());
-		updateProgram(state.getCurrentProgram());
-
-		// this has to happen after the location update
-		// since it clobbers the current address right now
-		updateAddress(state.getCurrentAddress());
-	}
-
-	/**
 	 * Get a list of completions for the given command prefix.
 	 *
 	 * @param cmd The command to try to complete.
@@ -73,31 +55,6 @@ public abstract class GhidraInterpreter implements Disposable {
 	 * @return A list of possible code completions.
 	 */
 	public abstract List<CodeCompletion> getCompletions(String cmd);
-
-	/**
-	 * Runs the given script with the arguments and state provided.
-	 *
-	 * The provided state is loaded into the interpreter at the beginning of
-	 * execution, and the values of the globals are then exported back into the
-	 * state after it completes.
-	 *
-	 * If the script cannot be found but the script is not running in headless mode,
-	 * the user will be prompted to ignore the error, which will cause the function
-	 * to simply continue instead of throwing an IllegalArgumentException.
-	 *
-	 * @throws IllegalArgumentException if the script does not exist
-	 * @throws IOException              if the script could not be read
-	 * @throws FileNotFoundException    if the script file wasn't found
-	 *
-	 * @param script          The script to run.
-	 *
-	 * @param scriptArguments The arguments to pass to the script.
-	 *
-	 * @param scriptState     The script to load before the script runs, and update
-	 *                        after the script finishes.
-	 */
-	public abstract void runScript(GhidraScript script, String[] scriptArguments, GhidraState scriptState)
-			throws IllegalArgumentException, FileNotFoundException, IOException;
 
 	/**
 	 * Sets the error output stream for this interpreter.
@@ -173,16 +130,4 @@ public abstract class GhidraInterpreter implements Disposable {
 	 * @param sel The new selection.
 	 */
 	public abstract void updateSelection(ProgramSelection sel);
-
-	/**
-	 * Updates a state with the current selection/location/etc. variables from the
-	 * interpreter.
-	 *
-	 * This is intended to be called after a call to runScript, to make sure that
-	 * any updates made to these variables during execution are reflected in the end
-	 * state.
-	 *
-	 * @param scriptState The state to update.
-	 */
-	public abstract void updateState(GhidraState scriptState);
 }

--- a/src/main/java/rubydragon/ScriptableGhidraInterpreter.java
+++ b/src/main/java/rubydragon/ScriptableGhidraInterpreter.java
@@ -1,0 +1,67 @@
+package rubydragon;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+import ghidra.app.script.GhidraScript;
+import ghidra.app.script.GhidraState;
+
+/**
+ * An interpreter that can also run scripts.
+ */
+public abstract class ScriptableGhidraInterpreter extends GhidraInterpreter {
+
+	/**
+	 * Loads a provided GhidraState into the interpreter.
+	 *
+	 * @param state The state to load.
+	 */
+	public void loadState(GhidraState state) {
+		updateHighlight(state.getCurrentHighlight());
+		updateLocation(state.getCurrentLocation());
+		updateSelection(state.getCurrentSelection());
+		updateProgram(state.getCurrentProgram());
+
+		// this has to happen after the location update
+		// since it clobbers the current address right now
+		updateAddress(state.getCurrentAddress());
+	}
+
+	/**
+	 * Runs the given script with the arguments and state provided.
+	 *
+	 * The provided state is loaded into the interpreter at the beginning of
+	 * execution, and the values of the globals are then exported back into the
+	 * state after it completes.
+	 *
+	 * If the script cannot be found but the script is not running in headless mode,
+	 * the user will be prompted to ignore the error, which will cause the function
+	 * to simply continue instead of throwing an IllegalArgumentException.
+	 *
+	 * @throws IllegalArgumentException if the script does not exist
+	 * @throws IOException              if the script could not be read
+	 * @throws FileNotFoundException    if the script file wasn't found
+	 *
+	 * @param script          The script to run.
+	 *
+	 * @param scriptArguments The arguments to pass to the script.
+	 *
+	 * @param scriptState     The script to load before the script runs, and update
+	 *                        after the script finishes.
+	 */
+	public abstract void runScript(GhidraScript script, String[] scriptArguments, GhidraState scriptState)
+			throws IllegalArgumentException, FileNotFoundException, IOException;
+
+	/**
+	 * Updates a state with the current selection/location/etc. variables from the
+	 * interpreter.
+	 *
+	 * This is intended to be called after a call to runScript, to make sure that
+	 * any updates made to these variables during execution are reflected in the end
+	 * state.
+	 *
+	 * @param scriptState The state to update.
+	 */
+	public abstract void updateState(GhidraState scriptState);
+
+}

--- a/src/main/java/rubydragon/clojure/ClojureGhidraInterpreter.java
+++ b/src/main/java/rubydragon/clojure/ClojureGhidraInterpreter.java
@@ -39,6 +39,7 @@ import ghidra.app.plugin.core.console.CodeCompletion;
 import ghidra.app.plugin.core.interpreter.InterpreterConsole;
 import ghidra.app.script.GhidraScript;
 import ghidra.app.script.GhidraState;
+import ghidra.program.flatapi.FlatProgramAPI;
 import ghidra.program.model.address.Address;
 import ghidra.program.model.listing.Program;
 import ghidra.program.util.ProgramLocation;
@@ -252,13 +253,15 @@ public class ClojureGhidraInterpreter extends GhidraInterpreter {
 	}
 
 	/**
-	 * Updates the program pointed to by the "ghidra/current-program" binding.
+	 * Updates the program pointed to by the "ghidra/current-program" binding, as
+	 * well as the "ghidra/current-api" flat api instance.
 	 *
 	 * @param program The new current program.
 	 */
 	@Override
 	public void updateProgram(Program program) {
 		RT.var("ghidra", "current-program", program);
+		RT.var("ghidra", "current-api", new FlatProgramAPI(program));
 	}
 
 	/**

--- a/src/main/java/rubydragon/clojure/ClojureGhidraInterpreter.java
+++ b/src/main/java/rubydragon/clojure/ClojureGhidraInterpreter.java
@@ -45,12 +45,12 @@ import ghidra.program.model.listing.Program;
 import ghidra.program.util.ProgramLocation;
 import ghidra.program.util.ProgramSelection;
 import ghidra.util.exception.AssertException;
-import rubydragon.GhidraInterpreter;
+import rubydragon.ScriptableGhidraInterpreter;
 
 /**
  * A Clojure intepreter for Ghidra.
  */
-public class ClojureGhidraInterpreter extends GhidraInterpreter {
+public class ClojureGhidraInterpreter extends ScriptableGhidraInterpreter {
 	private Thread replThread;
 	final private ClassLoader clojureClassLoader;
 

--- a/src/main/java/rubydragon/jshell/JShellGhidraInterpreter.java
+++ b/src/main/java/rubydragon/jshell/JShellGhidraInterpreter.java
@@ -168,9 +168,11 @@ public class JShellGhidraInterpreter extends GhidraInterpreter {
 		suggestions = analyzer.completionSuggestions(cmd, cmd.length(), anchor);
 		for (SourceCodeAnalysis.Suggestion s : suggestions) {
 			String c = s.continuation();
+
+			int commonLength = cmd.length() - anchor[0];
 			String added = "";
-			if (c.startsWith(cmd)) {
-				added = c.substring(cmd.length());
+			if (cmd.substring(anchor[0]).equals(c.substring(0, commonLength))) {
+				added = c.substring(commonLength);
 			}
 			CodeCompletion completion = new CodeCompletion(c, added, null);
 			result.add(completion);

--- a/src/main/java/rubydragon/jshell/JShellGhidraInterpreter.java
+++ b/src/main/java/rubydragon/jshell/JShellGhidraInterpreter.java
@@ -33,8 +33,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import ghidra.app.plugin.core.console.CodeCompletion;
 import ghidra.app.plugin.core.interpreter.InterpreterConsole;
-import ghidra.app.script.GhidraScript;
-import ghidra.app.script.GhidraState;
 import ghidra.program.flatapi.FlatProgramAPI;
 import ghidra.program.model.address.Address;
 import ghidra.program.model.listing.Program;
@@ -215,25 +213,6 @@ public class JShellGhidraInterpreter extends GhidraInterpreter {
 	}
 
 	/**
-	 * Does nothing, since this interpeter is only for interactive sessions and
-	 * doesn't support scripts.
-	 *
-	 * This is a sign that the parent class should probably be refactored so that a
-	 * nullsub like this doesn't need to exist.
-	 *
-	 * @param script          The script to run.
-	 *
-	 * @param scriptArguments The arguments to pass to the script.
-	 *
-	 * @param scriptState     The script to load before the script runs, and update
-	 *                        after the script finishes.
-	 */
-	@Override
-	public void runScript(GhidraScript script, String[] scriptArguments, GhidraState scriptState) {
-		return;
-	}
-
-	/**
 	 * Resets this interpreter.
 	 */
 	public void reset() {
@@ -352,22 +331,6 @@ public class JShellGhidraInterpreter extends GhidraInterpreter {
 		if (sel != null) {
 			setVariable("currentSelection", ProgramSelection.class, sel);
 		}
-	}
-
-	/**
-	 * Updates a state with the current selection/location/etc. variables from the
-	 * interpreter.
-	 *
-	 * Ignored because the JShell interpreter doesn't handle scripts.
-	 *
-	 * This is a sign that the parent class should probably be refactored so that a
-	 * nullsub like this doesn't need to exist.
-	 *
-	 * @param scriptState The state to update.
-	 */
-	@Override
-	public void updateState(GhidraState scriptState) {
-		return;
 	}
 
 }

--- a/src/main/java/rubydragon/jshell/JShellGhidraInterpreter.java
+++ b/src/main/java/rubydragon/jshell/JShellGhidraInterpreter.java
@@ -61,9 +61,10 @@ public class JShellGhidraInterpreter extends GhidraInterpreter {
 	private PrintWriter outWriter;
 	private OutputStream errStream;
 	private PrintWriter errWriter;
+	private boolean disposed = false;
 
 	private Runnable inputThread = () -> {
-		while (replReader != null) {
+		while (!disposed) {
 			try {
 				StringBuilder completeSnippet = new StringBuilder();
 				SourceCodeAnalysis analyzer = jshell.sourceCodeAnalysis();
@@ -148,7 +149,7 @@ public class JShellGhidraInterpreter extends GhidraInterpreter {
 	 */
 	@Override
 	public void dispose() {
-		replReader = null;
+		disposed = true;
 	}
 
 	/**

--- a/src/main/java/rubydragon/jshell/JShellGhidraInterpreter.java
+++ b/src/main/java/rubydragon/jshell/JShellGhidraInterpreter.java
@@ -35,6 +35,7 @@ import ghidra.app.plugin.core.console.CodeCompletion;
 import ghidra.app.plugin.core.interpreter.InterpreterConsole;
 import ghidra.app.script.GhidraScript;
 import ghidra.app.script.GhidraState;
+import ghidra.program.flatapi.FlatProgramAPI;
 import ghidra.program.model.address.Address;
 import ghidra.program.model.listing.Program;
 import ghidra.program.util.ProgramLocation;
@@ -135,6 +136,7 @@ public class JShellGhidraInterpreter extends GhidraInterpreter {
 
 		// declare the built-in variables
 		jshell.eval(String.format("%s currentAddress = null;", Address.class.getName()));
+		jshell.eval(String.format("%s currentAPI = null;", FlatProgramAPI.class.getName()));
 		jshell.eval(String.format("%s currentHighlight = null;", ProgramSelection.class.getName()));
 		jshell.eval(String.format("%s currentLocation = null;", ProgramLocation.class.getName()));
 		jshell.eval(String.format("%s currentProgram = null;", Program.class.getName()));
@@ -333,6 +335,7 @@ public class JShellGhidraInterpreter extends GhidraInterpreter {
 	public void updateProgram(Program program) {
 		if (program != null) {
 			setVariable("currentProgram", Program.class, program);
+			setVariable("currentAPI", FlatProgramAPI.class, new FlatProgramAPI(program));
 		}
 	}
 

--- a/src/main/java/rubydragon/kotlin/KotlinGhidraInterpreter.java
+++ b/src/main/java/rubydragon/kotlin/KotlinGhidraInterpreter.java
@@ -37,6 +37,7 @@ import ghidra.app.plugin.core.console.CodeCompletion;
 import ghidra.app.plugin.core.interpreter.InterpreterConsole;
 import ghidra.app.script.GhidraScript;
 import ghidra.app.script.GhidraState;
+import ghidra.program.flatapi.FlatProgramAPI;
 import ghidra.program.model.address.Address;
 import ghidra.program.model.listing.Program;
 import ghidra.program.util.ProgramLocation;
@@ -241,7 +242,8 @@ public class KotlinGhidraInterpreter extends GhidraInterpreter {
 	}
 
 	/**
-	 * Updates the program pointed to by the "currentProgram" binding.
+	 * Updates the program pointed to by the "currentProgram" binding, as well as
+	 * the "currentAPI" binding to a FlatProgramAPI instance.
 	 *
 	 * @param program The new current program.
 	 */
@@ -249,6 +251,7 @@ public class KotlinGhidraInterpreter extends GhidraInterpreter {
 	public void updateProgram(Program program) {
 		if (program != null) {
 			engine.put("currentProgram", program);
+			engine.put("currentAPI", new FlatProgramAPI(program));
 		}
 	}
 

--- a/src/main/java/rubydragon/kotlin/KotlinGhidraInterpreter.java
+++ b/src/main/java/rubydragon/kotlin/KotlinGhidraInterpreter.java
@@ -42,13 +42,13 @@ import ghidra.program.model.address.Address;
 import ghidra.program.model.listing.Program;
 import ghidra.program.util.ProgramLocation;
 import ghidra.program.util.ProgramSelection;
-import rubydragon.GhidraInterpreter;
 import rubydragon.MissingDragonDependency;
+import rubydragon.ScriptableGhidraInterpreter;
 
 /**
  * A Kotlin intepreter for Ghidra.
  */
-public class KotlinGhidraInterpreter extends GhidraInterpreter {
+public class KotlinGhidraInterpreter extends ScriptableGhidraInterpreter {
 	private Thread replThread;
 	private ScriptEngine engine;
 	private BufferedReader replReader;

--- a/src/main/java/rubydragon/ruby/RubyGhidraInterpreter.java
+++ b/src/main/java/rubydragon/ruby/RubyGhidraInterpreter.java
@@ -196,8 +196,10 @@ public class RubyGhidraInterpreter extends GhidraInterpreter {
 	 */
 	@Override
 	public void updateProgram(Program program) {
-		container.put("$current_program", program);
-		container.put("$current_api", new FlatProgramAPI(program));
+		if (program != null) {
+			container.put("$current_program", program);
+			container.put("$current_api", new FlatProgramAPI(program));
+		}
 	}
 
 	/**

--- a/src/main/java/rubydragon/ruby/RubyGhidraInterpreter.java
+++ b/src/main/java/rubydragon/ruby/RubyGhidraInterpreter.java
@@ -38,12 +38,12 @@ import ghidra.program.model.address.Address;
 import ghidra.program.model.listing.Program;
 import ghidra.program.util.ProgramLocation;
 import ghidra.program.util.ProgramSelection;
-import rubydragon.GhidraInterpreter;
+import rubydragon.ScriptableGhidraInterpreter;
 
 /**
  * A Ruby interpreter for Ghidra, built using JRuby.
  */
-public class RubyGhidraInterpreter extends GhidraInterpreter {
+public class RubyGhidraInterpreter extends ScriptableGhidraInterpreter {
 	private ScriptingContainer container;
 	private Thread irbThread;
 	private boolean disposed = false;

--- a/src/main/java/rubydragon/ruby/RubyGhidraInterpreter.java
+++ b/src/main/java/rubydragon/ruby/RubyGhidraInterpreter.java
@@ -33,6 +33,7 @@ import ghidra.app.plugin.core.console.CodeCompletion;
 import ghidra.app.plugin.core.interpreter.InterpreterConsole;
 import ghidra.app.script.GhidraScript;
 import ghidra.app.script.GhidraState;
+import ghidra.program.flatapi.FlatProgramAPI;
 import ghidra.program.model.address.Address;
 import ghidra.program.model.listing.Program;
 import ghidra.program.util.ProgramLocation;
@@ -188,13 +189,15 @@ public class RubyGhidraInterpreter extends GhidraInterpreter {
 	}
 
 	/**
-	 * Updates the current program in "$current_program" to the one provided.
+	 * Updates the current program in "$current_program" to the one provided, as
+	 * well as the "$current_api" variable holding a flat api instance.
 	 *
 	 * @param program The new current program.
 	 */
 	@Override
 	public void updateProgram(Program program) {
 		container.put("$current_program", program);
+		container.put("$current_api", new FlatProgramAPI(program));
 	}
 
 	/**

--- a/src/test/java/rubydragon/test/JShellGhidraInterpreterTest.java
+++ b/src/test/java/rubydragon/test/JShellGhidraInterpreterTest.java
@@ -70,6 +70,14 @@ public class JShellGhidraInterpreterTest {
 	}
 
 	@Test
+	public void testCurrentAPIDeclared() throws Exception {
+		writeCommand("currentAPI = null;");
+
+		assertEquals("null should be printed", "null", outputReader.readLine());
+		assertFalse(errorReader.ready());
+	}
+
+	@Test
 	public void testCurrentHighlightDeclared() throws Exception {
 		writeCommand("currentHighlight = null;");
 


### PR DESCRIPTION
Makes a number of improvements to JShell and the broader supporting implementation.

Tab completion for JShell has been made more robust to allow suggestions that do not replace the entire initial string.

GhidraInterpreter has been extended with ScriptableGhidraInterpreter to make script support optional for interactive interpreter engines.

currentAPI and similar interpreter variables have been added with a FlatProgramAPI instance.