### PR TITLE
New top-level methods & other startup improvements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ plugins {
 }
 
 dependencies {
-	implementation('org.jruby:jruby-complete:9.3.4.0')
+	implementation('org.jruby:jruby-complete:9.3.7.0')
 	implementation('org.clojure:clojure:1.11.1')
 	testImplementation('junit:junit:4.13')
 	runtimeOnly('org.jetbrains.kotlin:kotlin-scripting-jsr223:1.7.0')

--- a/src/main/java/rubydragon/ruby/RubyGhidraInterpreter.java
+++ b/src/main/java/rubydragon/ruby/RubyGhidraInterpreter.java
@@ -55,8 +55,12 @@ public class RubyGhidraInterpreter extends ScriptableGhidraInterpreter {
 	public RubyGhidraInterpreter() {
 		container = new ScriptingContainer(LocalContextScope.SINGLETHREAD, LocalVariableBehavior.PERSISTENT);
 		irbThread = new Thread(() -> {
-			// allow java-like package names, and import irb and completions
-			container.runScriptlet("def ghidra;Java::ghidra;end; require 'irb'; require 'irb/completion';");
+			try{
+				InputStream stream = getClass().getResourceAsStream("/scripts/ruby-init.rb");
+				container.runScriptlet(stream, "ruby-init.rb");
+			} catch(Throwable t){
+				throw new RuntimeException(t);
+			}
 			while (!disposed) {
 				container.runScriptlet("IRB.start");
 			}
@@ -107,6 +111,16 @@ public class RubyGhidraInterpreter extends ScriptableGhidraInterpreter {
 	}
 
 	/**
+	 * Sets up method proxies at the top level to mirror $script or $current_api methods, as jython does.
+	 */
+	public void createProxies() {
+		container.runScriptlet("(($current_api.methods - java.lang.Object.new.methods) - self.methods).each { |mn| \n"+
+			" define_method(mn){|*argv|($current_api).send(mn, *argv);}\n"+ //proxy the current object (hence not method binding)
+			" private(mn)\n"+ // hide from all other objects so we don't see it in autocomplete when called with an explicit receiver
+			" }");
+	}
+
+	/**
 	 * Runs the given script with the arguments and state provided.
 	 *
 	 * The provided state is loaded into the interpreter at the beginning of
@@ -126,9 +140,14 @@ public class RubyGhidraInterpreter extends ScriptableGhidraInterpreter {
 			throws IllegalArgumentException, FileNotFoundException, IOException {
 		InputStream scriptStream = script.getSourceFile().getInputStream();
 		loadState(scriptState);
+		Object savedAPI = container.get("$current_api");
 		container.put("$script", script);
+		container.put("$current_api", script);
 		container.put("ARGV", scriptArguments);
+		createProxies();
 		container.runScriptlet(scriptStream, script.getScriptName());
+		container.remove("$script");
+		container.put("$current_api", savedAPI);
 		updateState(scriptState);
 	}
 
@@ -212,6 +231,7 @@ public class RubyGhidraInterpreter extends ScriptableGhidraInterpreter {
 		if (program != null) {
 			container.put("$current_program", program);
 			container.put("$current_api", new FlatProgramAPI(program));
+			createProxies();
 		}
 	}
 

--- a/src/main/java/rubydragon/ruby/RubyGhidraInterpreter.java
+++ b/src/main/java/rubydragon/ruby/RubyGhidraInterpreter.java
@@ -114,7 +114,8 @@ public class RubyGhidraInterpreter extends ScriptableGhidraInterpreter {
 	 * Sets up method proxies at the top level to mirror $script or $current_api methods, as jython does.
 	 */
 	public void createProxies() {
-		container.runScriptlet("(($current_api.methods - java.lang.Object.new.methods) - self.methods).each { |mn| \n"+
+		// ignore base java Object, ruby Object, main, and Kernel methods. We don't want to overwrite any of them.
+		container.runScriptlet("((($current_api.methods - java.lang.Object.new.methods) - self.methods) - Kernel.methods).each { |mn| \n"+
 			" define_method(mn){|*argv|($current_api).send(mn, *argv);}\n"+ //proxy the current object (hence not method binding)
 			" private(mn)\n"+ // hide from all other objects so we don't see it in autocomplete when called with an explicit receiver
 			" }");

--- a/src/main/resources/scripts/ruby-init.rb
+++ b/src/main/resources/scripts/ruby-init.rb
@@ -1,0 +1,51 @@
+require 'irb'
+require 'irb/completion'
+
+# allow java-like package names, and import irb and completions
+def ghidra
+	Java::ghidra
+end
+
+#ghidra classes (mostly) have good toString values meant for jython, so just use them vs useless java class inspect
+class java::lang::Object
+	def inspect(*args)
+		return self.class.name.start_with?("Java::Ghidra") ? "#<#{to_string}>" : super(*args)
+	end
+end
+
+# Now configure IRB
+
+# JRuby-9.3 ships with a slightly broken irb, and we want to modify it anyway, so look at
+# https://github.com/ruby/irb/blob/master/lib/irb/init.rb#L367 where this was copied from
+module IRB
+  # enumerate possible rc-file base name generators
+  def IRB.rc_file_generators
+    if irbrc = ENV["IRBRC"]
+      yield proc{|rc| rc == "rc" ? irbrc : irbrc+rc}
+    end
+    if xdg_config_home = ENV["XDG_CONFIG_HOME"]
+      irb_home = File.join(xdg_config_home, "ghidra")
+      unless File.exist? irb_home
+        require 'fileutils'
+        FileUtils.mkdir_p irb_home
+      end
+      yield proc{|rc| irb_home + "/irb#{rc}"}
+    end
+    if home = ENV["HOME"]
+      yield proc{|rc| home+"/.irb#{rc}"}
+    end
+    # TODO: I'd love to do this, but this isn't available at startup
+#    current_dir = project_root_folder.project_locator.project_dir.to_s
+	current_dir = Dir.pwd
+#    yield proc{|rc| current_dir+"/.config/irb/irb#{rc}"}
+    yield proc{|rc| current_dir+"/.irb#{rc}"}
+#    yield proc{|rc| current_dir+"/irb#{rc.sub(/\A_?/, '.')}"}
+#    yield proc{|rc| current_dir+"/_irb#{rc}"}
+#    yield proc{|rc| current_dir+"/$irb#{rc}"}
+  end
+end
+
+# due to differing output and specialization, have a custom irbrc name
+IRB::IRBRC_EXT = "rc-ghidra"
+# TODO: supress constant override warning above
+


### PR DESCRIPTION
1. Update JRuby to latest
2. `$current_api` is always the current API, even in scripts
3. Expose as top level methods from `$current_api` (now the same as Python, +standard JRuby snake case adaptations)
4. Pull out all init code and put into resource script
5. `ghidra.*` java objects get `toString` called, not the default (unhelpful) `#inspect` to mirror Jython behavior. (most helpful for functions and addresses)
6. irbrc loading from `$HOME/.irbrc-ghidra` and `$GHIDRA_HOME/.irbrc-ghidra`

I attempted to add `$GHIDRA_PROJECT/.irbrc-ghidra` but we don't know the project until it's too late.

I debated fixing/adding prompts but that was too much work for this PR