### PR TITLE
update for ghidra 10.2.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,13 +12,13 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        ghidra: ["10.2.2"]
+        ghidra: ["10.2.3"]
         include:
-          - ghidra: "10.2.2"
-            ghidra-url: "https://github.com/NationalSecurityAgency/ghidra/releases/download/Ghidra_10.2.2_build/ghidra_10.2.2_PUBLIC_20221115.zip"
-            ghidra-sha256: "feb8a795696b406ad075e2c554c80c7ee7dd55f0952458f694ea1a918aa20ee3"
-            ghidra-filename: "ghidra_10.2.2_PUBLIC_20221115.zip"
-            ghidra-folder: "ghidra_10.2.2_PUBLIC"
+          - ghidra: "10.2.3"
+            ghidra-url: "https://github.com/NationalSecurityAgency/ghidra/releases/download/Ghidra_10.2.3_build/ghidra_10.2.3_PUBLIC_20230208.zip"
+            ghidra-sha256: "daf4d85ec1a8ca55bf766e97ec43a14b519cbd1060168e4ec45d429d23c31c38"
+            ghidra-filename: "ghidra_10.2.3_PUBLIC_20230208.zip"
+            ghidra-folder: "ghidra_10.2.3_PUBLIC"
 
     env:
       GHIDRA_INSTALL_DIR: /home/runner/ghidra/${{ matrix.ghidra-folder }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [2.2.0] - 2023-02-15
+### Changed
+ - Upgrade to Groovy 4.0.9
+ - Upgrade to JRuby 9.3.10.0
+ - Upgrade to Kotlin 1.8.10
+
+
 ## [2.1.0] - 2022-11-20
 ### Added
  - Groovy script capability (uses Groovy 4.0.6)

--- a/build.gradle
+++ b/build.gradle
@@ -19,12 +19,12 @@ plugins {
 }
 
 dependencies {
-	implementation('org.jruby:jruby-complete:9.3.9.0')
+	implementation('org.jruby:jruby-complete:9.4.1.0')
 	implementation('org.clojure:clojure:1.11.1')
-    implementation('org.apache.groovy:groovy:4.0.6')
-    implementation('org.apache.groovy:groovy-groovysh:4.0.6')
+    implementation('org.apache.groovy:groovy:4.0.9')
+    implementation('org.apache.groovy:groovy-groovysh:4.0.9')
 	testImplementation('junit:junit:4.13')
-	runtimeOnly('org.jetbrains.kotlin:kotlin-scripting-jsr223:1.7.20')
+	runtimeOnly('org.jetbrains.kotlin:kotlin-scripting-jsr223:1.8.10')
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -19,10 +19,10 @@ plugins {
 }
 
 dependencies {
-	implementation('org.jruby:jruby-complete:9.4.1.0')
+	implementation('org.jruby:jruby-complete:9.3.10.0')
 	implementation('org.clojure:clojure:1.11.1')
-    implementation('org.apache.groovy:groovy:4.0.9')
-    implementation('org.apache.groovy:groovy-groovysh:4.0.9')
+	implementation('org.apache.groovy:groovy:4.0.9')
+	implementation('org.apache.groovy:groovy-groovysh:4.0.9')
 	testImplementation('junit:junit:4.13')
 	runtimeOnly('org.jetbrains.kotlin:kotlin-scripting-jsr223:1.8.10')
 }

--- a/src/main/resources/scripts/ruby-init.rb
+++ b/src/main/resources/scripts/ruby-init.rb
@@ -3,20 +3,19 @@ require 'irb/completion'
 
 # allow java-like package names, and import irb and completions
 def ghidra
-	Java::ghidra
+  Java::ghidra
 end
 
 #ghidra classes (mostly) have good toString values meant for jython, so just use them vs useless java class inspect
 class java::lang::Object
-	def inspect(*args)
-		return self.class.name.start_with?("Java::Ghidra") ? "#<#{to_string}>" : super(*args)
-	end
+  def inspect(*args)
+    return self.class.name.start_with?("Java::Ghidra") ? "#<#{to_string}>" : super(*args)
+  end
 end
 
 # Now configure IRB
-
-# JRuby-9.3 ships with a slightly broken irb, and we want to modify it anyway, so look at
-# https://github.com/ruby/irb/blob/master/lib/irb/init.rb#L367 where this was copied from
+# this was copied from
+# https://github.com/ruby/irb/blob/ed9e435a6beba805b3a8b453369cc6117ec7e377/lib/irb/init.rb#L398
 module IRB
   # enumerate possible rc-file base name generators
   def IRB.rc_file_generators
@@ -24,24 +23,24 @@ module IRB
       yield proc{|rc| rc == "rc" ? irbrc : irbrc+rc}
     end
     if xdg_config_home = ENV["XDG_CONFIG_HOME"]
-      irb_home = File.join(xdg_config_home, "ghidra")
-      unless File.exist? irb_home
-        require 'fileutils'
-        FileUtils.mkdir_p irb_home
+      irb_home = File.join(xdg_config_home, "irb")
+      if File.directory?(irb_home)
+        yield proc{|rc| irb_home + "/irb#{rc}"}
       end
-      yield proc{|rc| irb_home + "/irb#{rc}"}
     end
     if home = ENV["HOME"]
       yield proc{|rc| home+"/.irb#{rc}"}
     end
+
     # TODO: I'd love to do this, but this isn't available at startup
-#    current_dir = project_root_folder.project_locator.project_dir.to_s
-	current_dir = Dir.pwd
-#    yield proc{|rc| current_dir+"/.config/irb/irb#{rc}"}
+#   current_dir = project_root_folder.project_locator.project_dir.to_s
+    current_dir = Dir.pwd
+
+#   yield proc{|rc| current_dir+"/.config/irb/irb#{rc}"}
     yield proc{|rc| current_dir+"/.irb#{rc}"}
-#    yield proc{|rc| current_dir+"/irb#{rc.sub(/\A_?/, '.')}"}
-#    yield proc{|rc| current_dir+"/_irb#{rc}"}
-#    yield proc{|rc| current_dir+"/$irb#{rc}"}
+#   yield proc{|rc| current_dir+"/irb#{rc.sub(/\A_?/, '.')}"}
+#   yield proc{|rc| current_dir+"/_irb#{rc}"}
+#   yield proc{|rc| current_dir+"/$irb#{rc}"}
   end
 end
 


### PR DESCRIPTION
Updates JRuby, Groovy, and Kotlin to newer versions.

JRuby has been kept on the 9.3 minor version, as 9.4 continues to have problems with IRB sessions on Windows machines.