### PR TITLE
update for ghidra 11.0.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,13 +12,13 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        ghidra: ["11.0"]
+        ghidra: ["11.0.2"]
         include:
-          - ghidra: "11.0"
-            ghidra-url: "https://github.com/NationalSecurityAgency/ghidra/releases/download/Ghidra_11.0_build/ghidra_11.0_PUBLIC_20231222.zip"
-            ghidra-sha256: "f1f240f91cf6b1dffc9a4148384ee3c6b269a8ae27c6f981577973e00043ad94"
-            ghidra-filename: "ghidra_11.0_PUBLIC_20231222.zip"
-            ghidra-folder: "ghidra_11.0_PUBLIC"
+          - ghidra: "11.0.2"
+            ghidra-url: "https://github.com/NationalSecurityAgency/ghidra/releases/download/Ghidra_11.0.2_build/ghidra_11.0.2_PUBLIC_20240326.zip"
+            ghidra-sha256: "4f16ae3f288f8c01fd1872e8e55b25c79744e7b1e8a9383c5e576668ca7d1906"
+            ghidra-filename: "ghidra_11.0.2_PUBLIC_20240326.zip"
+            ghidra-folder: "ghidra_11.0.2_PUBLIC"
 
     env:
       GHIDRA_INSTALL_DIR: /home/runner/ghidra/${{ matrix.ghidra-folder }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [3.3.0] - 2024-03-28
+### Changed
+ - Upgrade to JRuby 9.4.6.0 (Ruby 3.1.4)
+ - Upgrade to Clojure 1.11.2
+ - Upgrade to Groovy 4.0.20
+ - Upgrade to Kotlin 1.9.23
+
+
 ## [3.2.0] - 2023-12-24
 ### Changed
  - Upgrade to JRuby 9.4.5.0 (Ruby 3.1.4)

--- a/build.gradle
+++ b/build.gradle
@@ -19,12 +19,12 @@ plugins {
 }
 
 dependencies {
-	implementation('org.jruby:jruby-complete:9.4.5.0')
-	implementation('org.clojure:clojure:1.11.1')
-	implementation('org.apache.groovy:groovy:4.0.17')
-	implementation('org.apache.groovy:groovy-groovysh:4.0.17')
+	implementation('org.jruby:jruby-complete:9.4.6.0')
+	implementation('org.clojure:clojure:1.11.2')
+	implementation('org.apache.groovy:groovy:4.0.20')
+	implementation('org.apache.groovy:groovy-groovysh:4.0.20')
 	testImplementation('junit:junit:4.13.2')
-	runtimeOnly('org.jetbrains.kotlin:kotlin-scripting-jsr223:1.9.22')
+	runtimeOnly('org.jetbrains.kotlin:kotlin-scripting-jsr223:1.9.23')
 }
 
 test {


### PR DESCRIPTION
Updates Ruby, Clojure, Groovy, and Kotlin to current versions,
and updates the CI workflow for Ghidra 11.0.2.